### PR TITLE
chore: add fee for oft transfers

### DIFF
--- a/contracts/GMX_Adapter.sol
+++ b/contracts/GMX_Adapter.sol
@@ -2,15 +2,18 @@
 pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { MintBurnOFTAdapter } from "@layerzerolabs/oft-evm/contracts/MintBurnOFTAdapter.sol";
-import { IMintableBurnable } from "@layerzerolabs/oft-evm/contracts/interfaces/IMintableBurnable.sol";
-import { SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@layerzerolabs/oft-evm/contracts/OFTCore.sol";
-import { Origin } from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
+
 import { OFTMsgCodec } from "@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol";
-import { OFTComposeMsgCodec } from "@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol";
+
+import { IMintableBurnable } from "@layerzerolabs/oft-evm/contracts/interfaces/IMintableBurnable.sol";
+import { Origin, SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@layerzerolabs/oft-evm/contracts/OFTCore.sol";
+
+import { MintBurnOFTAdapter } from "@layerzerolabs/oft-evm/contracts/MintBurnOFTAdapter.sol";
+import { Fee } from "@layerzerolabs/oft-evm/contracts/Fee.sol";
 import { RateLimiter } from "@layerzerolabs/oapp-evm/contracts/oapp/utils/RateLimiter.sol";
 
 import { IOverridableInboundRatelimit, RateLimitExemptAddress } from "./interfaces/IOverridableInboundRatelimit.sol";
+import { IFeeWithOwner } from "./interfaces/IFeeWithOwner.sol";
 
 /**
  * @title MintBurnOFTAdapter Contract
@@ -19,7 +22,7 @@ import { IOverridableInboundRatelimit, RateLimitExemptAddress } from "./interfac
  * @dev For existing ERC20 tokens with exposed mint and burn permissions, this can be used to convert the token to crosschain compatibility.
  * @dev Unlike the vanilla OFT Adapter, multiple of these can exist for a given global mesh.
  */
-contract GMX_Adapter is MintBurnOFTAdapter, RateLimiter, IOverridableInboundRatelimit {
+contract GMX_Adapter is MintBurnOFTAdapter, RateLimiter, Fee, IOverridableInboundRatelimit, IFeeWithOwner {
     using OFTMsgCodec for bytes;
     using OFTMsgCodec for bytes32;
 
@@ -32,7 +35,7 @@ contract GMX_Adapter is MintBurnOFTAdapter, RateLimiter, IOverridableInboundRate
         IMintableBurnable _minterBurner,
         address _lzEndpoint,
         address _delegate
-    ) MintBurnOFTAdapter(_token, _minterBurner, _lzEndpoint, _delegate) Ownable(_delegate) {
+    ) MintBurnOFTAdapter(_token, _minterBurner, _lzEndpoint, _delegate) Ownable(_delegate) Fee() {
         _setRateLimits(_rateLimitConfigs);
     }
 
@@ -89,11 +92,17 @@ contract GMX_Adapter is MintBurnOFTAdapter, RateLimiter, IOverridableInboundRate
         uint256 _minAmountLD,
         uint32 _dstEid
     ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
-        /// @dev amountSentLD is amountLD with dust removed
-        /// @dev amountReceivedLD is amountSentLD with other token amount changes such as fee, etc.
-        /// @dev GMX does not have any "changes" and so the following is true:
-        ///         amountSentLD = amountReceivedLD
-        (amountSentLD, amountReceivedLD) = super._debit(_from, _amountLD, _minAmountLD, _dstEid);
+        /// @dev amountSentLD is amountLD with dust removed i.e. the amount being transferred.
+        /// @dev amountReceivedLD is amountSentLD with fee, etc.
+        /// amountSentLD = amountReceivedLD (sent crosschain) + fee (in contract) + dust (stays with user)
+        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+        uint256 fee = amountSentLD - amountReceivedLD;
+
+        /// @dev Burn and then mint to prevent supply overflows
+        minterBurner.burn(_from, amountSentLD);
+
+        /// @dev Fee amt accues in the contract and can be withdrawn by owner.
+        if (fee > 0) minterBurner.mint(address(this), fee);
 
         /// @dev If the sender is an exemptAddress (FeeDistributor) then we do NOT refill the rate limiter.
         if (!exemptAddresses[msg.sender]) {
@@ -130,5 +139,60 @@ contract GMX_Adapter is MintBurnOFTAdapter, RateLimiter, IOverridableInboundRate
         }
 
         super._lzReceive(_origin, _guid, _message, _executor, _extraData);
+    }
+
+    /**
+     * @dev Internal function to mock the amount mutation from a OFT debit() operation.
+     * @param _amountLD The amount to send in local decimals.
+     * @param _minAmountLD The minimum amount to send in local decimals.
+     * @dev _dstEid The destination endpoint ID.
+     * @return amountSentLD The amount sent, in local decimals.
+     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.
+     *
+     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.
+     */
+    function _debitView(
+        uint256 _amountLD,
+        uint256 _minAmountLD,
+        uint32 _dstEid
+    ) internal view virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
+        /// @dev Apply the fee on the amount being transferred, then remove dust from `amount - fee`.
+        uint256 fee = getFee(_dstEid, _removeDust(_amountLD));
+
+        /// @dev Use `_amountLD` instead of `_removeDust(_amountLD)` because:
+        /// @dev _removeDust(_removeDust(_amountLD) - fee) <= _removeDust(_amountLD - fee) <= amountSentLD
+        /// @dev amt = 106, dust = decimal 1.
+        /// @dev preDust = _removeDust(100 - 1) = 90
+        /// @dev noDust = _removeDust(106 - 1) = 100
+        amountReceivedLD = _removeDust(_amountLD - fee);
+
+        /// @dev The amount to burn is the amount being transferred plus the fee.
+        /// @dev (100+1) is the burn amount and the dust is 4.
+        amountSentLD = fee + amountReceivedLD;
+
+        /// @dev Check for slippage.
+        if (amountReceivedLD < _minAmountLD) {
+            revert SlippageExceeded(amountReceivedLD, _minAmountLD);
+        }
+    }
+
+    /**
+     * @notice Withdraw the fee from the contract.
+     * @dev Since this is a MintBurn OFT Adapter the contract's balance is ALWAYS the fee amount.
+     * @dev Callable by owner, this supports withdrawing to a target address.
+     * @dev Withdraw amounts are capped at the fee amount in the contract.
+     * @param _to The address to withdraw the fee to.
+     * @param _amount The amount to withdraw.
+     */
+    function withdrawFee(address _to, uint256 _amount) external virtual onlyOwner {
+        if (_to == address(0)) revert ZeroAddress();
+        if (_amount == 0) revert ZeroAmount();
+
+        /// @dev If this is a lockbox adapter then we need to track the fee amount in the contract.
+        uint256 totalFee = innerToken.balanceOf(address(this));
+        if (_amount > totalFee) revert ExceedsFeeAccrued(_amount, totalFee);
+
+        innerToken.transfer(_to, _amount);
+        emit FeeWithdrawn(_to, _amount);
     }
 }

--- a/contracts/interfaces/IFeeWithOwner.sol
+++ b/contracts/interfaces/IFeeWithOwner.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+interface IFeeWithOwner {
+    error ZeroAmount();
+    error ZeroAddress();
+    error ExceedsFeeAccrued(uint256 requestedAmount, uint256 availableAmount);
+
+    event FeeWithdrawn(address indexed to, uint256 amount);
+
+    function withdrawFee(address to, uint256 _amount) external;
+}


### PR DESCRIPTION
This PR computes Fee on `transferAmt` which is the amount being transferred via a layerzero message. 

The amount deducted from the user is the `transferAmt + feeAmt` 
The amount sent across is `transferAmt`
The amount in the contract and can be withdrawn by the owner to a target address is `feeAmt`

dust is left at the sender's wallet.